### PR TITLE
Refactor API key handling for HMAC verification

### DIFF
--- a/beam/server/handlers/api/middleware.go
+++ b/beam/server/handlers/api/middleware.go
@@ -87,17 +87,10 @@ func (m *APIAuthMiddleware) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Verify signature
-		// Note: TODO:  I will need to reconstruct the secret from a secure store
-		// For now, we verify by regenerating the signature with the stored hash
-		// This is a simplified approach - a full implementation would use proper HMAC verification
-		expectedSignature := crypto.GenerateSignature(apiKey.SecretHash, r.Method, r.URL.Path, timestamp)
-		if signature != expectedSignature {
-			// For development/testing, also accept direct secret key verification
-			if !crypto.VerifySignature(apiKey.SecretHash, r.Method, r.URL.Path, timestamp, signature) {
-				sendAPIError(w, "SignatureMismatch", "Invalid signature", http.StatusForbidden)
-				return
-			}
+		// Verify signature using the stored secret key
+		if !crypto.VerifySignature(apiKey.SecretKey, r.Method, r.URL.Path, timestamp, signature) {
+			sendAPIError(w, "SignatureMismatch", "Invalid signature", http.StatusForbidden)
+			return
 		}
 
 		// Update last used timestamp (async to not slow down request)
@@ -160,5 +153,5 @@ func (m *APIAuthMiddleware) verifyPresignedToken(r *http.Request, token string) 
 	}
 
 	// Verify token
-	return crypto.VerifyPresignedToken(apiKey.SecretHash, r.Method, bucket, key, expiresAt, token)
+	return crypto.VerifyPresignedToken(apiKey.SecretKey, r.Method, bucket, key, expiresAt, token)
 }

--- a/pkg/db/api_keys.go
+++ b/pkg/db/api_keys.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/tachRoutine/beamdrop-go/pkg/crypto"
 	"github.com/tachRoutine/beamdrop-go/pkg/logger"
 	"gorm.io/gorm"
 )
@@ -16,8 +15,8 @@ type APIKey struct {
 	ID          uint       `gorm:"primaryKey" json:"id"`
 	Name        string     `gorm:"size:255;not null" json:"name"`
 	AccessKeyID string     `gorm:"column:access_key_id;uniqueIndex;size:24;not null" json:"accessKeyId"`
-	SecretHash  string     `gorm:"column:secret_hash;size:64;not null" json:"-"` // Stored as hash
-	Permissions string     `gorm:"type:text" json:"permissions"`                 // JSON permissions
+	SecretKey   string     `gorm:"column:secret_key;size:64;not null" json:"-"` // Stored for HMAC verification
+	Permissions string     `gorm:"type:text" json:"permissions"`                // JSON permissions
 	BucketScope string     `gorm:"column:bucket_scope;size:255" json:"bucketScope,omitempty"`
 	ExpiresAt   *time.Time `gorm:"column:expires_at" json:"expiresAt,omitempty"`
 	LastUsedAt  *time.Time `gorm:"column:last_used_at" json:"lastUsedAt,omitempty"`
@@ -56,9 +55,6 @@ func CreateAPIKey(name string, permissions string, bucketScope string, expiresIn
 		return nil, "", err
 	}
 
-	// Hash the secret key for storage
-	secretHash := crypto.HashSecret(secretKey)
-
 	var expiresAt *time.Time
 	if expiresIn != nil {
 		t := time.Now().Add(*expiresIn)
@@ -68,7 +64,7 @@ func CreateAPIKey(name string, permissions string, bucketScope string, expiresIn
 	apiKey := &APIKey{
 		Name:        name,
 		AccessKeyID: accessKeyID,
-		SecretHash:  secretHash,
+		SecretKey:   secretKey, // Store secret for HMAC verification
 		Permissions: permissions,
 		BucketScope: bucketScope,
 		ExpiresAt:   expiresAt,


### PR DESCRIPTION
Replace the secret hash with a secret key for HMAC verification in the API authentication process. This change simplifies the signature verification logic and enhances security by using the actual secret key.