### PR TITLE
Add max-storage configuration and enforcement

### DIFF
--- a/beam/server/server.go
+++ b/beam/server/server.go
@@ -63,7 +63,6 @@ func New(sharedDir string, flags config.Flags) *Server {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Increment request counter
 	db.IncrementRequests()
 
 	// Build middleware chain

--- a/beam/server/server.go
+++ b/beam/server/server.go
@@ -69,6 +69,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Build middleware chain
 	var handler http.Handler = s.mux
 
+	// Apply max storage check before writes
+	handler = middleware.MaxStorageCheck(s.sharedDir, s.flags.MaxStorage)(handler)
+
 	// Apply auth middleware
 	handler = s.authMiddleware.Middleware(handler)
 

--- a/cmd/beam/main.go
+++ b/cmd/beam/main.go
@@ -53,6 +53,18 @@ func envInt(flagName, envName string, flagVal *int) {
 	}
 }
 
+// envInt64 sets the int64 flag from an env var when the flag was not explicitly set.
+func envInt64(flagName, envName string, flagVal *int64) {
+	if isFlagSet(flagName) {
+		return
+	}
+	if v := os.Getenv(envName); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			*flagVal = n
+		}
+	}
+}
+
 // envDuration sets the duration flag from an env var when the flag was not explicitly set.
 func envDuration(flagName, envName string, flagVal *time.Duration) {
 	if isFlagSet(flagName) {
@@ -90,12 +102,13 @@ func main() {
 	logLevel := flag.String("log-level", "info", "Log level: debug, info, warn, error")
 	rateLimit := flag.Int("rate-limit", 100, "General rate limit in requests/min per IP (0 = disabled)")
 	shutdownTimeout := flag.Duration("shutdown-timeout", 30*time.Second, "Graceful shutdown timeout")
+	maxStorage := flag.Int64("max-storage", 0, "Maximum total storage in bytes (0 = unlimited)")
 
 	// NOTE:Here i default it to 0 so when it zero we know that the flag wasnt passed
 	// Since the flag is a non-boolean value
 	port := flag.Int("port", 0, "Set the port that beamdrop will run on")
 	flag.Parse()
-	
+
 	if *versionFlag {
 		styles.InfoStyle.Println("Beamdrop Version:", config.VERSION)
 		return
@@ -121,6 +134,7 @@ func main() {
 	envInt("port", "BEAMDROP_PORT", port)
 	envInt("rate-limit", "BEAMDROP_RATE_LIMIT", rateLimit)
 	envDuration("shutdown-timeout", "BEAMDROP_SHUTDOWN_TIMEOUT", shutdownTimeout)
+	envInt64("max-storage", "BEAMDROP_MAX_STORAGE", maxStorage)
 
 	// Initialize structured logger before anything else.
 	// Terminal gets colored human-readable output; JSON logs go to <sharedDir>/.beamdrop/beamdrop.log
@@ -149,6 +163,7 @@ func main() {
 		RateLimit:       *rateLimit,
 		ShutdownTimeout: *shutdownTimeout,
 		DBPath:          *dbPath,
+		MaxStorage:      *maxStorage,
 	}
 
 	if flag.NArg() > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,7 @@ type Flags struct {
 	RateLimit       int           // General rate limit in requests/min (0 = disabled)
 	ShutdownTimeout time.Duration // Graceful shutdown timeout (default 30s)
 	DBPath          string        // Path to database file (default: <sharedDir>/.beamdrop/beamdrop.db)
+	MaxStorage      int64         // Maximum total storage in bytes (0 = unlimited)
 }
 
 func GetDBPath() string {

--- a/pkg/middleware/disk.go
+++ b/pkg/middleware/disk.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/ekilie/beamdrop/pkg/errors"
+	"github.com/ekilie/beamdrop/pkg/storage"
+)
+
+// MaxStorageCheck rejects write requests when usage exceeds maxBytes.
+// If maxBytes is 0, the check is disabled (unlimited storage).
+func MaxStorageCheck(sharedDir string, maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if maxBytes <= 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Only check on write methods
+			switch r.Method {
+			case http.MethodPost, http.MethodPut, http.MethodPatch:
+			default:
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			usage, err := storage.GetDirStorageUsage(sharedDir)
+			if err != nil {
+				errors.InternalError("Failed to check storage usage").WithCause(err).WriteHTTPResponse(w)
+				return
+			}
+
+			if usage.UsedBytes >= uint64(maxBytes) {
+				errors.StorageFull().WriteHTTPResponse(w)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// DirUsage represents storage usage for the shared directory
+type DirUsage struct {
+	UsedBytes     uint64        `json:"usedBytes"`
+	TotalBytes    uint64        `json:"totalBytes,omitempty"` // filesystem total (for %)
+	FreeBytes     uint64        `json:"freeBytes,omitempty"`
+	UsagePercent  float64       `json:"usagePercent"` // 0-100
+	LastUpdated   time.Time     `json:"lastUpdated"`
+}
+
+// NOTE:we use cached usage to avoid hammering disk on every request
+var (
+	usageCache     DirUsage
+	usageCacheLock sync.RWMutex
+	usageCacheTTL  = 5 * time.Second 
+)
+
+// GetDirStorageUsage returns current usage of the shared directory (only user files, excludes .beamdrop internals if you want)
+func GetDirStorageUsage(dir string) (DirUsage, error) {
+	usageCacheLock.RLock()
+	if time.Since(usageCache.LastUpdated) < usageCacheTTL && usageCache.UsedBytes > 0 {
+		cached := usageCache
+		usageCacheLock.RUnlock()
+		return cached, nil
+	}
+	usageCacheLock.RUnlock()
+
+	
+	var usage DirUsage
+	usage.TotalBytes, usage.FreeBytes = getFilesystemStats(dir)
+
+	// Calculate actual used bytes by walking the shared dir (exclude hidden BeamDrop folders)
+	used, err := calculateDirSize(dir)
+	if err != nil {
+		return DirUsage{}, fmt.Errorf("failed to calculate directory size: %w", err)
+	}
+
+	usage.UsedBytes = used
+	if usage.TotalBytes > 0 {
+		usage.UsagePercent = float64(usage.UsedBytes) / float64(usage.TotalBytes) * 100
+	}
+
+	usage.LastUpdated = time.Now()
+
+	// update cache
+	usageCacheLock.Lock()
+	usageCache = usage
+	usageCacheLock.Unlock()
+
+	return usage, nil
+}
+
+// calculateDirSize walks the directory and sums file sizes (skips BeamDrop internal dirs)
+func calculateDirSize(root string) (uint64, error) {
+	var size uint64
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err // or filepath.SkipDir if you want to be lenient
+		}
+
+		// Skip BeamDrop internal folders so they don't count toward user quota
+		if d.IsDir() {
+			name := d.Name()
+			if name == ".beamdrop" || name == ".beamdrop_data" || name == ".beamdrop_trash" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only regular files
+		if info, err := d.Info(); err == nil && !info.IsDir() {
+			size += uint64(info.Size())
+		}
+		return nil
+	})
+
+	return size, err
+}
+
+// getFilesystemStats returns total and free bytes of the filesystem containing 'path'
+// Uses fast syscall (no walking needed)
+func getFilesystemStats(path string) (total, free uint64) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		// fallback: return 0,0 — we'll still use the walked size
+		return 0, 0
+	}
+
+	// Blocks * block size
+	total = uint64(stat.Blocks) * uint64(stat.Bsize)
+	free = uint64(stat.Bavail) * uint64(stat.Bsize) // available to non-root
+	return total, free
+}

--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -10,23 +10,23 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// DirUsage represents storage usage for the shared directory
+// DirUsage represents storage usage for a directory.
 type DirUsage struct {
-	UsedBytes     uint64        `json:"usedBytes"`
-	TotalBytes    uint64        `json:"totalBytes,omitempty"` // filesystem total (for %)
-	FreeBytes     uint64        `json:"freeBytes,omitempty"`
-	UsagePercent  float64       `json:"usagePercent"` // 0-100
-	LastUpdated   time.Time     `json:"lastUpdated"`
+	UsedBytes    uint64    `json:"usedBytes"`
+	TotalBytes   uint64    `json:"totalBytes,omitempty"`
+	FreeBytes    uint64    `json:"freeBytes,omitempty"`
+	UsagePercent float64   `json:"usagePercent"`
+	LastUpdated  time.Time `json:"lastUpdated"`
 }
 
-// NOTE:we use cached usage to avoid hammering disk on every request
+// Cached usage to avoid frequent disk walks.
 var (
 	usageCache     DirUsage
 	usageCacheLock sync.RWMutex
-	usageCacheTTL  = 5 * time.Second 
+	usageCacheTTL  = 5 * time.Second
 )
 
-// GetDirStorageUsage returns current usage of the shared directory (only user files, excludes .beamdrop internals if you want)
+// GetDirStorageUsage returns cached or freshly computed usage for dir.
 func GetDirStorageUsage(dir string) (DirUsage, error) {
 	usageCacheLock.RLock()
 	if time.Since(usageCache.LastUpdated) < usageCacheTTL && usageCache.UsedBytes > 0 {
@@ -36,11 +36,9 @@ func GetDirStorageUsage(dir string) (DirUsage, error) {
 	}
 	usageCacheLock.RUnlock()
 
-	
 	var usage DirUsage
 	usage.TotalBytes, usage.FreeBytes = getFilesystemStats(dir)
 
-	// Calculate actual used bytes by walking the shared dir (exclude hidden BeamDrop folders)
 	used, err := calculateDirSize(dir)
 	if err != nil {
 		return DirUsage{}, fmt.Errorf("failed to calculate directory size: %w", err)
@@ -53,7 +51,6 @@ func GetDirStorageUsage(dir string) (DirUsage, error) {
 
 	usage.LastUpdated = time.Now()
 
-	// update cache
 	usageCacheLock.Lock()
 	usageCache = usage
 	usageCacheLock.Unlock()
@@ -61,16 +58,15 @@ func GetDirStorageUsage(dir string) (DirUsage, error) {
 	return usage, nil
 }
 
-// calculateDirSize walks the directory and sums file sizes (skips BeamDrop internal dirs)
+// calculateDirSize walks root, summing file sizes (skips .beamdrop dirs).
 func calculateDirSize(root string) (uint64, error) {
 	var size uint64
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err // or filepath.SkipDir if you want to be lenient
+			return err
 		}
 
-		// Skip BeamDrop internal folders so they don't count toward user quota
 		if d.IsDir() {
 			name := d.Name()
 			if name == ".beamdrop" || name == ".beamdrop_data" || name == ".beamdrop_trash" {
@@ -79,7 +75,6 @@ func calculateDirSize(root string) (uint64, error) {
 			return nil
 		}
 
-		// Only regular files
 		if info, err := d.Info(); err == nil && !info.IsDir() {
 			size += uint64(info.Size())
 		}
@@ -89,17 +84,14 @@ func calculateDirSize(root string) (uint64, error) {
 	return size, err
 }
 
-// getFilesystemStats returns total and free bytes of the filesystem containing 'path'
-// Uses fast syscall (no walking needed)
+// getFilesystemStats returns total and free bytes via statfs syscall.
 func getFilesystemStats(path string) (total, free uint64) {
 	var stat unix.Statfs_t
 	if err := unix.Statfs(path, &stat); err != nil {
-		// fallback: return 0,0 — we'll still use the walked size
 		return 0, 0
 	}
 
-	// Blocks * block size
 	total = uint64(stat.Blocks) * uint64(stat.Bsize)
-	free = uint64(stat.Bavail) * uint64(stat.Bsize) // available to non-root
+	free = uint64(stat.Bavail) * uint64(stat.Bsize)
 	return total, free
 }


### PR DESCRIPTION
Introduce a max-storage flag to set a configurable storage limit. Implement a middleware to enforce this limit on write requests, along with functions to calculate and cache storage usage for the shared directory. Refactor related documentation for clarity.