### PR TITLE
Implement Go client for BeamDrop API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ beamdrop -dir /path/to/share -api-auth -tls-cert cert.pem -tls-key key.pem
 
 - **Web UI + File Browser:** Drag, drop, rename, move, and organize files.
 - **S3-Compatible API:** Works with existing AWS SDKs and scripts.
+- **Official Go client:** In-repo SDK for signed bucket, object, and presigned URL operations.
 - **Shareable Links:** Optional password and expiry.
 - **Single Binary:** Runs anywhere, zero dependencies.
 - **Secure & Production-Ready:** TLS, rate limiting, structured logging.
@@ -78,6 +79,51 @@ beamdrop -dir /path/to/share -api-auth -tls-cert cert.pem -tls-key key.pem
 - **Prometheus metrics**: `/metrics` endpoint with request counters, latency histograms, storage gauges, and a ready-to-import Grafana dashboard
 
 ## Installation
+
+## Go Client
+
+Beamdrop now includes a first-party Go client in this repository:
+
+```go
+import "github.com/ekilie/beamdrop/pkg/client"
+```
+
+Minimal example:
+
+```go
+ctx := context.Background()
+
+sdk, err := client.New(client.Config{
+  BaseURL:     "http://localhost:7777",
+  AccessKeyID: "BDK_your_access_key",
+  SecretKey:   "sk_your_secret_key",
+})
+if err != nil {
+  log.Fatal(err)
+}
+
+if _, err := sdk.CreateBucketIfNotExists(ctx, "uploads"); err != nil {
+  log.Fatal(err)
+}
+
+if _, err := sdk.PutObject(ctx, "uploads", "hello.txt", []byte("hello beamdrop")); err != nil {
+  log.Fatal(err)
+}
+
+object, err := sdk.GetObject(ctx, "uploads", "hello.txt")
+if err != nil {
+  log.Fatal(err)
+}
+
+fmt.Println(string(object.Body))
+```
+
+Current client scope:
+
+- bucket operations
+- object upload, download, metadata, and delete
+- client-side presigned URL generation
+- server-side presigned URL management via `/api/v1/presign`
 
 ### Quick Install (macOS & Linux)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -189,9 +189,31 @@ func (c *Client) PresignObjectURL(method, bucket, key string, expiresAt time.Tim
 }
 
 func (c *Client) CreatePresignedURL(ctx context.Context, request CreatePresignedURLRequest) (*PresignedURL, error) {
-	var response PresignedURL
-	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/presign", nil, jsonBody(request), &response); err != nil {
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpRequest, err := c.newRequest(ctx, http.MethodPost, "/api/v1/presign", nil, bytes.NewReader(body))
+	if err != nil {
 		return nil, err
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+
+	httpResponse, err := c.httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	if httpResponse.StatusCode < 200 || httpResponse.StatusCode >= 300 {
+		apiErr := decodeAPIError(httpResponse)
+		httpResponse.Body.Close()
+		return nil, apiErr
+	}
+	defer httpResponse.Body.Close()
+
+	var response PresignedURL
+	if err := json.NewDecoder(httpResponse.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	return &response, nil
 }
@@ -319,17 +341,6 @@ func (c *Client) newRequest(ctx context.Context, method, path string, query url.
 	}
 
 	return request, nil
-}
-
-func jsonBody(payload any) io.Reader {
-	if payload == nil {
-		return nil
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return bytes.NewReader(nil)
-	}
-	return bytes.NewReader(body)
 }
 
 func bucketPath(bucket string) string {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,345 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ekilie/beamdrop/pkg/crypto"
+)
+
+const defaultUserAgent = "beamdrop-go-client/0.1"
+
+type Config struct {
+	BaseURL     string
+	AccessKeyID string
+	SecretKey   string
+	HTTPClient  *http.Client
+	Now         func() time.Time
+	UserAgent   string
+}
+
+type Client struct {
+	baseURL     *url.URL
+	httpClient  *http.Client
+	accessKeyID string
+	secretKey   string
+	now         func() time.Time
+	userAgent   string
+}
+
+func New(config Config) (*Client, error) {
+	if strings.TrimSpace(config.BaseURL) == "" {
+		return nil, ErrInvalidBaseURL
+	}
+
+	baseURL, err := url.Parse(config.BaseURL)
+	if err != nil || baseURL.Scheme == "" || baseURL.Host == "" {
+		return nil, ErrInvalidBaseURL
+	}
+
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 2 * time.Minute}
+	}
+
+	now := config.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+
+	userAgent := config.UserAgent
+	if userAgent == "" {
+		userAgent = defaultUserAgent
+	}
+
+	return &Client{
+		baseURL:     baseURL,
+		httpClient:  httpClient,
+		accessKeyID: config.AccessKeyID,
+		secretKey:   config.SecretKey,
+		now:         now,
+		userAgent:   userAgent,
+	}, nil
+}
+
+func (c *Client) ListBuckets(ctx context.Context) (*BucketList, error) {
+	var response BucketList
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v1/buckets", nil, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) CreateBucket(ctx context.Context, name string) (*BucketCreated, error) {
+	var response BucketCreated
+	if err := c.doJSON(ctx, http.MethodPut, bucketPath(name), nil, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) CreateBucketIfNotExists(ctx context.Context, name string) (*BucketCreated, error) {
+	var response BucketCreated
+	query := url.Values{"createIfNotExists": []string{"true"}}
+	if err := c.doJSON(ctx, http.MethodPut, bucketPath(name), query, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) DeleteBucket(ctx context.Context, name string) error {
+	return c.doNoContent(ctx, http.MethodDelete, bucketPath(name), nil)
+}
+
+func (c *Client) BucketExists(ctx context.Context, name string) (bool, error) {
+	err := c.doNoContent(ctx, http.MethodHead, bucketPath(name), nil)
+	if err == nil {
+		return true, nil
+	}
+	if apiErr, ok := err.(*APIError); ok && apiErr.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
+func (c *Client) ListObjects(ctx context.Context, bucket string, options ListObjectsOptions) (*ObjectList, error) {
+	query := url.Values{}
+	if options.Prefix != "" {
+		query.Set("prefix", options.Prefix)
+	}
+	if options.Delimiter != "" {
+		query.Set("delimiter", options.Delimiter)
+	}
+	if options.MaxKeys > 0 {
+		query.Set("max-keys", fmt.Sprintf("%d", options.MaxKeys))
+	}
+
+	var response ObjectList
+	if err := c.doJSON(ctx, http.MethodGet, bucketPath(bucket), query, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) PutObject(ctx context.Context, bucket, key string, body []byte) (*ObjectCreated, error) {
+	return c.PutObjectReader(ctx, bucket, key, bytes.NewReader(body))
+}
+
+func (c *Client) PutObjectReader(ctx context.Context, bucket, key string, body io.Reader) (*ObjectCreated, error) {
+	var response ObjectCreated
+	if err := c.doJSON(ctx, http.MethodPut, objectPath(bucket, key), nil, body, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) GetObject(ctx context.Context, bucket, key string) (*ObjectBody, error) {
+	response, err := c.doRaw(ctx, http.MethodGet, objectPath(bucket, key), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (c *Client) HeadObject(ctx context.Context, bucket, key string) (*ObjectMetadata, error) {
+	response, err := c.doRaw(ctx, http.MethodHead, objectPath(bucket, key), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &response.ObjectMetadata, nil
+}
+
+func (c *Client) DeleteObject(ctx context.Context, bucket, key string) error {
+	return c.doNoContent(ctx, http.MethodDelete, objectPath(bucket, key), nil)
+}
+
+func (c *Client) ObjectExists(ctx context.Context, bucket, key string) (bool, error) {
+	err := c.doNoContent(ctx, http.MethodHead, objectPath(bucket, key), nil)
+	if err == nil {
+		return true, nil
+	}
+	if apiErr, ok := err.(*APIError); ok && apiErr.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
+func (c *Client) PresignObjectURL(method, bucket, key string, expiresAt time.Time) (string, error) {
+	if c.accessKeyID == "" || c.secretKey == "" {
+		return "", ErrMissingCredentials
+	}
+
+	method = strings.ToUpper(method)
+	path := objectPath(bucket, key)
+	relative := &url.URL{Path: path}
+	presignedURL := c.baseURL.ResolveReference(relative)
+	query := presignedURL.Query()
+	query.Set("access_key", c.accessKeyID)
+	query.Set("expires", expiresAt.UTC().Format(time.RFC3339))
+	query.Set("token", crypto.GeneratePresignedToken(c.secretKey, method, bucket, key, expiresAt.UTC()))
+	presignedURL.RawQuery = query.Encode()
+	return presignedURL.String(), nil
+}
+
+func (c *Client) CreatePresignedURL(ctx context.Context, request CreatePresignedURLRequest) (*PresignedURL, error) {
+	var response PresignedURL
+	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/presign", nil, jsonBody(request), &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) ListPresignedURLs(ctx context.Context) (*PresignedURLList, error) {
+	var response PresignedURLList
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v1/presign", nil, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) GetPresignedURL(ctx context.Context, token string) (*PresignedURL, error) {
+	var response PresignedURL
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v1/presign/"+url.PathEscape(token), nil, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) DeletePresignedURL(ctx context.Context, token string) error {
+	return c.doNoContent(ctx, http.MethodDelete, "/api/v1/presign/"+url.PathEscape(token), nil)
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, query url.Values, body io.Reader, dst any) error {
+	response, err := c.do(ctx, method, path, query, body)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if dst == nil || response.StatusCode == http.StatusNoContent {
+		io.Copy(io.Discard, response.Body)
+		return nil
+	}
+
+	if err := json.NewDecoder(response.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) doNoContent(ctx context.Context, method, path string, query url.Values) error {
+	response, err := c.do(ctx, method, path, query, nil)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	io.Copy(io.Discard, response.Body)
+	return nil
+}
+
+func (c *Client) doRaw(ctx context.Context, method, path string, query url.Values, body io.Reader) (*ObjectBody, error) {
+	response, err := c.do(ctx, method, path, query, body)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	metadata := metadataFromHeaders(response.Header)
+	result := &ObjectBody{ObjectMetadata: metadata}
+	if method != http.MethodHead {
+		result.Body, err = io.ReadAll(response.Body)
+		if err != nil {
+			return nil, fmt.Errorf("read response body: %w", err)
+		}
+	}
+	return result, nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, query url.Values, body io.Reader) (*http.Response, error) {
+	request, err := c.newRequest(ctx, method, path, query, body)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		apiErr := decodeAPIError(response)
+		response.Body.Close()
+		return nil, apiErr
+	}
+
+	return response, nil
+}
+
+func (c *Client) newRequest(ctx context.Context, method, path string, query url.Values, body io.Reader) (*http.Request, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, ErrInvalidPath
+	}
+
+	relative := &url.URL{Path: path}
+	if len(query) > 0 {
+		relative.RawQuery = query.Encode()
+	}
+
+	requestURL := c.baseURL.ResolveReference(relative)
+	request, err := http.NewRequestWithContext(ctx, method, requestURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("User-Agent", c.userAgent)
+	request.Header.Set("Accept", "application/json")
+
+	if method == http.MethodPut || method == http.MethodPost {
+		if request.Header.Get("Content-Type") == "" {
+			request.Header.Set("Content-Type", "application/octet-stream")
+		}
+	}
+
+	if c.accessKeyID != "" || c.secretKey != "" {
+		if c.accessKeyID == "" || c.secretKey == "" {
+			return nil, ErrMissingCredentials
+		}
+
+		timestamp := c.now().UTC().Format(time.RFC3339)
+		signature := crypto.GenerateSignature(c.secretKey, method, path, timestamp)
+		request.Header.Set("Authorization", "Bearer "+c.accessKeyID+":"+signature)
+		request.Header.Set("X-Beamdrop-Date", timestamp)
+	}
+
+	return request, nil
+}
+
+func jsonBody(payload any) io.Reader {
+	if payload == nil {
+		return nil
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return bytes.NewReader(nil)
+	}
+	return bytes.NewReader(body)
+}
+
+func bucketPath(bucket string) string {
+	return "/api/v1/buckets/" + url.PathEscape(bucket)
+}
+
+func objectPath(bucket, key string) string {
+	segments := strings.Split(key, "/")
+	for index, segment := range segments {
+		segments[index] = url.PathEscape(segment)
+	}
+	return bucketPath(bucket) + "/" + strings.Join(segments, "/")
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,225 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	beamcrypto "github.com/ekilie/beamdrop/pkg/crypto"
+)
+
+func TestListBucketsSignsRequest(t *testing.T) {
+	const (
+		accessKey = "BDK_test"
+		secretKey = "sk_test"
+	)
+
+	fixedTime := time.Date(2026, 4, 23, 10, 11, 12, 0, time.UTC)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/buckets" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		expectedSignature := beamcrypto.GenerateSignature(secretKey, http.MethodGet, "/api/v1/buckets", fixedTime.Format(time.RFC3339))
+		expectedAuthorization := "Bearer " + accessKey + ":" + expectedSignature
+
+		if got := r.Header.Get("Authorization"); got != expectedAuthorization {
+			t.Fatalf("unexpected authorization header: %s", got)
+		}
+		if got := r.Header.Get("X-Beamdrop-Date"); got != fixedTime.Format(time.RFC3339) {
+			t.Fatalf("unexpected timestamp header: %s", got)
+		}
+
+		writeJSON(t, w, http.StatusOK, BucketList{Buckets: []BucketInfo{{Name: "media"}}, Count: 1})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL, accessKey, secretKey, fixedTime)
+
+	response, err := client.ListBuckets(context.Background())
+	if err != nil {
+		t.Fatalf("ListBuckets returned error: %v", err)
+	}
+	if response.Count != 1 || len(response.Buckets) != 1 || response.Buckets[0].Name != "media" {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+}
+
+func TestGetObjectReturnsBodyAndMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/buckets/media/folder/hello%20world.txt" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", "5")
+		w.Header().Set("ETag", `"abc123"`)
+		w.Header().Set("Last-Modified", time.Unix(0, 0).UTC().Format(http.TimeFormat))
+		_, _ = io.WriteString(w, "hello")
+	}))
+	defer server.Close()
+
+	client := newAnonymousTestClient(t, server.URL)
+
+	response, err := client.GetObject(context.Background(), "media", "folder/hello world.txt")
+	if err != nil {
+		t.Fatalf("GetObject returned error: %v", err)
+	}
+	if string(response.Body) != "hello" {
+		t.Fatalf("unexpected body: %q", string(response.Body))
+	}
+	if response.ETag != "abc123" || response.ContentType != "text/plain" || response.ContentLength != 5 {
+		t.Fatalf("unexpected metadata: %+v", response.ObjectMetadata)
+	}
+}
+
+func TestDeleteBucketReturnsStructuredError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, http.StatusConflict, map[string]any{
+			"code":     "BUCKET_NOT_EMPTY",
+			"category": "CONFLICT",
+			"message":  "Bucket is not empty",
+		})
+	}))
+	defer server.Close()
+
+	client := newAnonymousTestClient(t, server.URL)
+
+	err := client.DeleteBucket(context.Background(), "media")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusConflict || apiErr.Code != "BUCKET_NOT_EMPTY" {
+		t.Fatalf("unexpected error: %+v", apiErr)
+	}
+}
+
+func TestPresignObjectURL(t *testing.T) {
+	expiresAt := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	client := newTestClient(t, "https://beamdrop.example.com", "BDK_test", "sk_test", expiresAt)
+
+	presignedURL, err := client.PresignObjectURL(http.MethodGet, "media", "folder/file.txt", expiresAt)
+	if err != nil {
+		t.Fatalf("PresignObjectURL returned error: %v", err)
+	}
+
+	if !strings.Contains(presignedURL, "access_key=BDK_test") {
+		t.Fatalf("missing access key in URL: %s", presignedURL)
+	}
+	if !strings.Contains(presignedURL, "expires=2026-04-23T12%3A00%3A00Z") {
+		t.Fatalf("missing expiration in URL: %s", presignedURL)
+	}
+	if !strings.Contains(presignedURL, "token=") {
+		t.Fatalf("missing token in URL: %s", presignedURL)
+	}
+	if !strings.Contains(presignedURL, "/api/v1/buckets/media/folder/file.txt") {
+		t.Fatalf("missing object path in URL: %s", presignedURL)
+	}
+}
+
+func TestCreatePresignedURLUsesJSONBody(t *testing.T) {
+	expiresIn := int64(3600)
+	maxDownloads := 2
+	createdAt := time.Date(2026, 4, 23, 14, 0, 0, 0, time.UTC)
+	var baseURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/presign" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("unexpected content type: %s", got)
+		}
+
+		var request CreatePresignedURLRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		expected := CreatePresignedURLRequest{
+			Bucket:       "media",
+			Key:          "folder/file.txt",
+			Method:       http.MethodGet,
+			ExpiresIn:    &expiresIn,
+			MaxDownloads: &maxDownloads,
+		}
+		if !reflect.DeepEqual(request, expected) {
+			t.Fatalf("unexpected request payload: %+v", request)
+		}
+
+		writeJSON(t, w, http.StatusCreated, PresignedURL{
+			Token:        "abc123",
+			URL:          baseURL + "/dl/abc123",
+			Bucket:       "media",
+			Key:          "folder/file.txt",
+			Method:       http.MethodGet,
+			MaxDownloads: &maxDownloads,
+			CreatedAt:    createdAt,
+		})
+	}))
+	defer server.Close()
+	baseURL = server.URL
+
+	client := newAnonymousTestClient(t, server.URL)
+	response, err := client.CreatePresignedURL(context.Background(), CreatePresignedURLRequest{
+		Bucket:       "media",
+		Key:          "folder/file.txt",
+		Method:       http.MethodGet,
+		ExpiresIn:    &expiresIn,
+		MaxDownloads: &maxDownloads,
+	})
+	if err != nil {
+		t.Fatalf("CreatePresignedURL returned error: %v", err)
+	}
+	if response.Token != "abc123" || response.URL == "" {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+}
+
+func newTestClient(t *testing.T, baseURL, accessKeyID, secretKey string, now time.Time) *Client {
+	t.Helper()
+
+	client, err := New(Config{
+		BaseURL:     baseURL,
+		AccessKeyID: accessKeyID,
+		SecretKey:   secretKey,
+		Now:         func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	return client
+}
+
+func newAnonymousTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+
+	client, err := New(Config{BaseURL: baseURL})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	return client
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, payload any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("failed to write JSON response: %v", err)
+	}
+}

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrInvalidBaseURL     = errors.New("invalid base URL")
+	ErrMissingCredentials = errors.New("missing beamdrop credentials")
+	ErrInvalidPath        = errors.New("invalid path")
+)
+
+type APIError struct {
+	StatusCode int            `json:"-"`
+	Code       string         `json:"code,omitempty"`
+	Category   string         `json:"category,omitempty"`
+	Message    string         `json:"message,omitempty"`
+	Details    map[string]any `json:"details,omitempty"`
+	Retryable  bool           `json:"-"`
+	RetryAfter int            `json:"-"`
+	Body       []byte         `json:"-"`
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Code != "" && e.Message != "" {
+		return fmt.Sprintf("beamdrop API error (%d %s): %s", e.StatusCode, e.Code, e.Message)
+	}
+	if e.Message != "" {
+		return fmt.Sprintf("beamdrop API error (%d): %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("beamdrop API error (%d)", e.StatusCode)
+}
+
+func decodeAPIError(response *http.Response) *APIError {
+	apiErr := &APIError{
+		StatusCode: response.StatusCode,
+		Retryable:  strings.EqualFold(response.Header.Get("X-Retryable"), "true"),
+	}
+
+	if retryAfter := response.Header.Get("Retry-After"); retryAfter != "" {
+		if seconds, err := strconv.Atoi(retryAfter); err == nil {
+			apiErr.RetryAfter = seconds
+		}
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err == nil {
+		apiErr.Body = body
+		if len(body) > 0 {
+			if err := json.Unmarshal(body, apiErr); err != nil || apiErr.Message == "" {
+				apiErr.Message = strings.TrimSpace(string(body))
+			}
+		}
+	}
+
+	if apiErr.Message == "" {
+		apiErr.Message = http.StatusText(response.StatusCode)
+	}
+
+	return apiErr
+}

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type BucketInfo struct {
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+type BucketList struct {
+	Buckets []BucketInfo `json:"buckets"`
+	Count   int          `json:"count"`
+}
+
+type BucketCreated struct {
+	Bucket   string `json:"bucket"`
+	Created  string `json:"created,omitempty"`
+	Exists   bool   `json:"exists,omitempty"`
+	Location string `json:"location"`
+}
+
+type ObjectInfo struct {
+	Key          string    `json:"key"`
+	Size         int64     `json:"size"`
+	LastModified time.Time `json:"lastModified"`
+	ETag         string    `json:"etag"`
+	ContentType  string    `json:"contentType,omitempty"`
+}
+
+type CommonPrefix struct {
+	Prefix string `json:"prefix"`
+}
+
+type ObjectList struct {
+	Bucket         string         `json:"bucket"`
+	Prefix         string         `json:"prefix"`
+	Delimiter      string         `json:"delimiter,omitempty"`
+	MaxKeys        int            `json:"maxKeys"`
+	IsTruncated    bool           `json:"isTruncated"`
+	Contents       []ObjectInfo   `json:"contents"`
+	CommonPrefixes []CommonPrefix `json:"commonPrefixes,omitempty"`
+}
+
+type ObjectCreated struct {
+	Bucket string `json:"bucket"`
+	Key    string `json:"key"`
+	ETag   string `json:"etag"`
+	Size   int64  `json:"size"`
+	URL    string `json:"url"`
+}
+
+type ObjectMetadata struct {
+	ContentType   string
+	ContentLength int64
+	ETag          string
+	LastModified  string
+}
+
+type ObjectBody struct {
+	ObjectMetadata
+	Body []byte
+}
+
+type ListObjectsOptions struct {
+	Prefix    string
+	Delimiter string
+	MaxKeys   int
+}
+
+type CreatePresignedURLRequest struct {
+	Bucket       string `json:"bucket"`
+	Key          string `json:"key"`
+	Method       string `json:"method,omitempty"`
+	ExpiresIn    *int64 `json:"expiresIn,omitempty"`
+	MaxDownloads *int   `json:"maxDownloads,omitempty"`
+}
+
+type PresignedURL struct {
+	ID            uint       `json:"id,omitempty"`
+	Token         string     `json:"token"`
+	URL           string     `json:"url,omitempty"`
+	Bucket        string     `json:"bucket"`
+	Key           string     `json:"key"`
+	Method        string     `json:"method"`
+	ExpiresAt     *time.Time `json:"expiresAt,omitempty"`
+	MaxDownloads  *int       `json:"maxDownloads,omitempty"`
+	DownloadCount int        `json:"downloadCount,omitempty"`
+	CreatedBy     string     `json:"createdBy,omitempty"`
+	CreatedAt     time.Time  `json:"createdAt"`
+	Message       string     `json:"message,omitempty"`
+}
+
+type PresignedURLList struct {
+	URLs  []PresignedURL `json:"urls"`
+	Count int            `json:"count"`
+}
+
+func metadataFromHeaders(headers http.Header) ObjectMetadata {
+	length, _ := strconv.ParseInt(headers.Get("Content-Length"), 10, 64)
+	return ObjectMetadata{
+		ContentType:   headers.Get("Content-Type"),
+		ContentLength: length,
+		ETag:          strings.Trim(headers.Get("ETag"), `"`),
+		LastModified:  headers.Get("Last-Modified"),
+	}
+}


### PR DESCRIPTION
Introduce a Go client for managing buckets and objects in the BeamDrop API, enhancing functionality with improved error handling and comprehensive tests. Update the README with documentation and usage examples for the new client.