### PR TITLE
feat: make JWT secret configurable and persistent 

### DIFF
--- a/cmd/beam/help.go
+++ b/cmd/beam/help.go
@@ -37,6 +37,8 @@ Options:
 		Maximum total storage, e.g. 500MB, 10GB, 1TB (0 = unlimited)
   -shutdown-timeout duration
 		Graceful shutdown timeout for draining connections (default 30s)
+  -jwt-secret string
+		JWT signing secret (min 32 bytes; auto-generated and persisted if omitted)
   -qr
 		Enable QR code generation
   -h
@@ -60,6 +62,7 @@ Environment Variables:
     BEAMDROP_RATE_LIMIT       -rate-limit
     BEAMDROP_MAX_STORAGE      -max-storage
     BEAMDROP_SHUTDOWN_TIMEOUT -shutdown-timeout (Go duration, e.g. "30s")
+    BEAMDROP_JWT_SECRET        -jwt-secret
 
 S3-like API:
   When running, beamdrop exposes an S3-compatible API at /api/v1/

--- a/cmd/beam/main.go
+++ b/cmd/beam/main.go
@@ -190,7 +190,7 @@ func main() {
 	logger.Init(*logLevel, *sharedDir)
 
 	// Initialize JWT secret (from flag, persisted file, or auto-generate)
-	if err := auth.InitJWTSecret(*jwtSecret, *sharedDir); err != nil {
+	if err := auth.InitJWTSecret(*jwtSecret); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/beam/main.go
+++ b/cmd/beam/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ekilie/beamdrop/beam/server"
 	"github.com/ekilie/beamdrop/config"
+	"github.com/ekilie/beamdrop/pkg/auth"
 	"github.com/ekilie/beamdrop/pkg/db"
 	"github.com/ekilie/beamdrop/pkg/logger"
 	"github.com/ekilie/beamdrop/pkg/styles"
@@ -131,6 +132,7 @@ func main() {
 	shutdownTimeout := flag.Duration("shutdown-timeout", 30*time.Second, "Graceful shutdown timeout")
 	maxStorageStr := flag.String("max-storage", "0", "Maximum total storage, e.g. 500MB, 10GB, 1TB (0 = unlimited)")
 	trustedProxies := flag.String("trusted-proxies", "", "Comma-separated list of trusted proxy IPs/CIDRs for X-Forwarded-For (empty = trust direct connection only)")
+	jwtSecret := flag.String("jwt-secret", "", "JWT signing secret (min 32 bytes; empty = auto-generate and persist to <dir>/.beamdrop/jwt_secret)")
 
 	// NOTE:Here i default it to 0 so when it zero we know that the flag wasnt passed
 	// Since the flag is a non-boolean value
@@ -164,6 +166,7 @@ func main() {
 	envDuration("shutdown-timeout", "BEAMDROP_SHUTDOWN_TIMEOUT", shutdownTimeout)
 	envStr("max-storage", "BEAMDROP_MAX_STORAGE", maxStorageStr)
 	envStr("trusted-proxies", "BEAMDROP_TRUSTED_PROXIES", trustedProxies)
+	envStr("jwt-secret", "BEAMDROP_JWT_SECRET", jwtSecret)
 
 	// Parse max-storage from human-readable format
 	maxStorage, err := parseByteSize(*maxStorageStr)
@@ -185,6 +188,12 @@ func main() {
 	// Initialize structured logger before anything else.
 	// Terminal gets colored human-readable output; JSON logs go to <sharedDir>/.beamdrop/beamdrop.log
 	logger.Init(*logLevel, *sharedDir)
+
+	// Initialize JWT secret (from flag, persisted file, or auto-generate)
+	if err := auth.InitJWTSecret(*jwtSecret, *sharedDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Apply custom DB path if provided in the flag
 	if *dbPath != "" {
@@ -211,6 +220,7 @@ func main() {
 		DBPath:          *dbPath,
 		MaxStorage:      maxStorage,
 		TrustedProxies:  *trustedProxies,
+		JWTSecret:       *jwtSecret,
 	}
 
 	if flag.NArg() > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -75,6 +75,7 @@ type Flags struct {
 	DBPath          string        // Path to database file (default: <sharedDir>/.beamdrop/beamdrop.db)
 	MaxStorage      int64         // Maximum total storage in bytes (0 = unlimited)
 	TrustedProxies  string        // Comma-separated list of trusted proxy IPs/CIDRs
+	JWTSecret       string        // Explicit JWT signing secret (min 32 bytes; empty = auto-generate and persist)
 }
 
 func GetDBPath() string {

--- a/pkg/auth/password.go
+++ b/pkg/auth/password.go
@@ -5,7 +5,10 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -25,18 +28,58 @@ var (
 	revokedTokensMu sync.RWMutex
 )
 
-func init() {
-	// Generate a random JWT secret on startup
-	jwtSecret = make([]byte, 32)
-	if _, err := rand.Read(jwtSecret); err != nil {
-		panic("CRITICAL: failed to generate JWT secret: " + err.Error())
+// InitJWTSecret initialises the JWT signing key. It accepts an explicit secret
+// (from -jwt-secret / BEAMDROP_JWT_SECRET) and the shared directory root.
+//
+// Resolution order:
+//  1. If `secret` is non-empty, use it (must be ≥ 32 bytes).
+//  2. Else, try to load from <sharedDir>/.beamdrop/jwt_secret.
+//  3. Else, generate a random 32-byte key and persist it to that file.
+//
+// This must be called once during startup, before any JWT operations.
+func InitJWTSecret(secret string, sharedDir string) error {
+	const minLen = 32
+	secretFile := filepath.Join(sharedDir, ".beamdrop", "jwt_secret")
+
+	switch {
+	case secret != "":
+		// Explicit secret provided via flag/env var
+		if len(secret) < minLen {
+			return fmt.Errorf("jwt-secret must be at least %d bytes, got %d", minLen, len(secret))
+		}
+		jwtSecret = []byte(secret)
+		slog.Info("Using JWT secret from configuration")
+
+	default:
+		// Try to load from file
+		data, err := os.ReadFile(secretFile)
+		if err == nil && len(data) >= minLen {
+			jwtSecret = data
+			slog.Info("Loaded JWT secret from file", "path", secretFile)
+		} else {
+			// Generate a new random secret
+			jwtSecret = make([]byte, 32)
+			if _, err := rand.Read(jwtSecret); err != nil {
+				return fmt.Errorf("failed to generate JWT secret: %w", err)
+			}
+			// Persist it
+			dir := filepath.Dir(secretFile)
+			if err := os.MkdirAll(dir, 0700); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", dir, err)
+			}
+			if err := os.WriteFile(secretFile, jwtSecret, 0600); err != nil {
+				return fmt.Errorf("failed to persist JWT secret to %s: %w", secretFile, err)
+			}
+			slog.Info("Generated and persisted new JWT secret", "path", secretFile)
+		}
 	}
+
 	// Share the key with the crypto package for at-rest encryption
 	crypto.SetEncryptionKey(jwtSecret)
+	return nil
 }
 
 // EncryptionKey returns the 32-byte key used for encrypting secrets at rest.
-// This is derived from the JWT secret which is randomly generated per process.
 func EncryptionKey() []byte {
 	return jwtSecret
 }

--- a/pkg/auth/password.go
+++ b/pkg/auth/password.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ekilie/beamdrop/config"
 	"github.com/ekilie/beamdrop/pkg/crypto"
 	"github.com/ekilie/beamdrop/pkg/db"
 	"github.com/golang-jwt/jwt/v5"
@@ -29,17 +30,17 @@ var (
 )
 
 // InitJWTSecret initialises the JWT signing key. It accepts an explicit secret
-// (from -jwt-secret / BEAMDROP_JWT_SECRET) and the shared directory root.
+// (from -jwt-secret / BEAMDROP_JWT_SECRET).
 //
 // Resolution order:
 //  1. If `secret` is non-empty, use it (must be ≥ 32 bytes).
-//  2. Else, try to load from <sharedDir>/.beamdrop/jwt_secret.
+//  2. Else, try to load from <ConfigDir>/jwt_secret (~/.beamdrop/jwt_secret).
 //  3. Else, generate a random 32-byte key and persist it to that file.
 //
 // This must be called once during startup, before any JWT operations.
-func InitJWTSecret(secret string, sharedDir string) error {
+func InitJWTSecret(secret string) error {
 	const minLen = 32
-	secretFile := filepath.Join(sharedDir, ".beamdrop", "jwt_secret")
+	secretFile := filepath.Join(config.ConfigDir, "jwt_secret")
 
 	switch {
 	case secret != "":
@@ -62,11 +63,7 @@ func InitJWTSecret(secret string, sharedDir string) error {
 			if _, err := rand.Read(jwtSecret); err != nil {
 				return fmt.Errorf("failed to generate JWT secret: %w", err)
 			}
-			// Persist it
-			dir := filepath.Dir(secretFile)
-			if err := os.MkdirAll(dir, 0700); err != nil {
-				return fmt.Errorf("failed to create directory %s: %w", dir, err)
-			}
+			// Persist it (ConfigDir is already created by config.init())
 			if err := os.WriteFile(secretFile, jwtSecret, 0600); err != nil {
 				return fmt.Errorf("failed to persist JWT secret to %s: %w", secretFile, err)
 			}


### PR DESCRIPTION
## Summary

Replaces the random per-process JWT secret with a configurable, persistent one so that tokens and encrypted API key secrets survive server restarts.

## Changes

- **`pkg/auth/password.go`** — Replaced `init()` with explicit `InitJWTSecret(secret string)` function. Resolution order:
  1. Explicit value from `-jwt-secret` flag / `BEAMDROP_JWT_SECRET` env var (must be ≥ 32 bytes)
  2. Load from `~/.beamdrop/jwt_secret` if the file exists
  3. Auto-generate a random 32-byte key and persist it to that file (mode `0600`)
- **`config/config.go`** — Added `JWTSecret` field to `Flags` struct
- **`cmd/beam/main.go`** — Added `-jwt-secret` flag and `BEAMDROP_JWT_SECRET` env var; calls `InitJWTSecret()` after logger init but before DB init (required because API key encryption depends on the key)
- **`cmd/beam/help.go`** — Documented the new flag and env var

## Why

Previously, the JWT signing key was regenerated randomly on every startup. This meant:
- All active JWT tokens were invalidated on restart
- API key secrets encrypted with AES-256-GCM became unrecoverable after restart

The secret is stored at `~/.beamdrop/jwt_secret`, reusing the existing config directory created by `config.init()`.

Closes #89