### PR TITLE
feat: Add Beamdrop storage usage metrics + fix memory leaks across webhook emitter, locks, and orphan cleaner

### DIFF
--- a/internal/server/handlers/stats.go
+++ b/internal/server/handlers/stats.go
@@ -6,8 +6,109 @@ import (
 	"net/http"
 
 	"github.com/ekilie/beamdrop/pkg/db"
+	"github.com/ekilie/beamdrop/pkg/storage"
+	"github.com/ekilie/beamdrop/pkg/system"
 )
 
+// StorageUsage provides Beamdrop-specific storage metrics for the HTTP stats endpoint.
+type StorageUsage struct {
+	UsedBytes      uint64  `json:"usedBytes"`
+	TotalBytes     uint64  `json:"totalBytes"`
+	FreeBytes      uint64  `json:"freeBytes"`
+	AllocatedBytes int64   `json:"allocatedBytes"`
+	AvailableBytes uint64  `json:"availableBytes"`
+	UsagePercent   float64 `json:"usagePercent"`
+}
+
+// StatsHandlerParams holds the parameters needed for the stats handler.
+type StatsHandlerParams struct {
+	SharedDir          string
+	DisableSystemStats bool
+	MaxStorage         int64
+}
+
+// StatsHandlerWithStorage returns an HTTP handler that includes storage metrics.
+func StatsHandlerWithStorage(sharedDir string, disableSystemStats bool, maxStorage int64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			json.NewEncoder(w).Encode(map[string]string{"error": "Method not allowed"})
+			return
+		}
+
+		stats, err := db.GetStats()
+		if err != nil {
+			slog.Error("Failed to get server stats", "error", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": "Failed to get server stats"})
+			return
+		}
+
+		// Compute storage usage
+		var storageUsage StorageUsage
+		dirUsage, dirErr := storage.GetDirStorageUsage(sharedDir)
+		if dirErr == nil {
+			storageUsage = computeStorageUsage(dirUsage.UsedBytes, dirUsage.TotalBytes, dirUsage.FreeBytes, maxStorage)
+		} else {
+			sysStats := system.GetSystemStats(sharedDir)
+			storageUsage = computeStorageUsage(0, sysStats.Disk.Total, sysStats.Disk.Free, maxStorage)
+		}
+
+		response := map[string]any{
+			"downloads":       stats.Downloads,
+			"requests":        stats.Requests,
+			"uploads":         stats.Uploads,
+			"bytesUploaded":   stats.BytesUploaded,
+			"bytesDownloaded": stats.BytesDownloaded,
+			"startTime":       stats.StartTime,
+			"storage":         storageUsage,
+		}
+
+		if !disableSystemStats {
+			sysStats := system.GetSystemStats(sharedDir)
+			response["system"] = sysStats
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}
+}
+
+// computeStorageUsage builds the StorageUsage struct from raw filesystem
+// metrics and the optional maxStorage allocation.
+func computeStorageUsage(usedBytes, totalBytes, freeBytes uint64, maxStorage int64) StorageUsage {
+	s := StorageUsage{
+		UsedBytes:      usedBytes,
+		TotalBytes:     totalBytes,
+		FreeBytes:      freeBytes,
+		AllocatedBytes: maxStorage,
+	}
+
+	if maxStorage > 0 {
+		allocated := uint64(maxStorage)
+		if usedBytes >= allocated {
+			s.AvailableBytes = 0
+			s.UsagePercent = 100.0
+		} else {
+			s.AvailableBytes = allocated - usedBytes
+			if allocated > 0 {
+				s.UsagePercent = float64(usedBytes) / float64(allocated) * 100
+			}
+		}
+	} else {
+		s.AvailableBytes = freeBytes
+		if totalBytes > 0 {
+			s.UsagePercent = float64(usedBytes) / float64(totalBytes) * 100
+		}
+	}
+
+	return s
+}
+
+// StatsHandler is the legacy handler that returns DB stats only (no storage metrics).
+// It is kept for backward compatibility; StatsHandlerWithStorage is preferred.
 func StatsHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -47,7 +47,7 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("/auth/status", authHandler.Status)
 
 	// Stats
-	s.mux.HandleFunc("/stats", StatsHandlerWithStorage(s.sharedDir, s.flags.DisableSystemStats, s.flags.MaxStorage))
+	s.mux.HandleFunc("/stats", handlers.StatsHandlerWithStorage(s.sharedDir, s.flags.DisableSystemStats, s.flags.MaxStorage))
 	s.mux.HandleFunc("/ws/stats", StatsSocketHandler(s.sharedDir, s.getAllowedOrigins(), s.flags.DisableSystemStats, s.flags.MaxStorage))
 
 	// Logs

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -47,8 +47,8 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("/auth/status", authHandler.Status)
 
 	// Stats
-	s.mux.HandleFunc("/stats", handlers.StatsHandler)
-	s.mux.HandleFunc("/ws/stats", StatsSocketHandler(s.sharedDir, s.getAllowedOrigins(), s.flags.DisableSystemStats)) //TODO: will come up with  better structure for the websockts
+	s.mux.HandleFunc("/stats", StatsHandlerWithStorage(s.sharedDir, s.flags.DisableSystemStats, s.flags.MaxStorage))
+	s.mux.HandleFunc("/ws/stats", StatsSocketHandler(s.sharedDir, s.getAllowedOrigins(), s.flags.DisableSystemStats, s.flags.MaxStorage))
 
 	// Logs
 	s.mux.HandleFunc("/api/logs", handlers.LogsHandler())

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ekilie/beamdrop/pkg/db"
+	"github.com/ekilie/beamdrop/pkg/storage"
 	"github.com/ekilie/beamdrop/pkg/system"
 	"github.com/gorilla/websocket"
 )
@@ -43,7 +44,30 @@ func newUpgrader(allowedOrigins []string) websocket.Upgrader {
 	}
 }
 
-// ExtendedStats contains both database stats and system stats
+// StorageUsage provides Beamdrop-specific storage metrics.
+// It includes the actual disk usage of the shared directory, filesystem
+// capacity, and any max-storage allocation set via the -max-storage flag.
+type StorageUsage struct {
+	// UsedBytes is the total bytes consumed by files in the shared directory
+	// (excluding internal .beamdrop metadata directories).
+	UsedBytes uint64 `json:"usedBytes"`
+	// TotalBytes is the total capacity of the filesystem where the shared directory lives.
+	TotalBytes uint64 `json:"totalBytes"`
+	// FreeBytes is the free space on that filesystem.
+	FreeBytes uint64 `json:"freeBytes"`
+	// AllocatedBytes is the storage cap set via -max-storage (0 = unlimited).
+	AllocatedBytes int64 `json:"allocatedBytes"`
+	// AvailableBytes is the effective space available for new uploads:
+	//   - If maxStorage is set: max(0, allocatedBytes - usedBytes)
+	//   - If unlimited: free space on disk
+	AvailableBytes uint64 `json:"availableBytes"`
+	// UsagePercent is the percentage of the effective limit used:
+	//   - If maxStorage is set: usedBytes / allocatedBytes * 100
+	//   - If unlimited: usedBytes / totalBytes * 100
+	UsagePercent float64 `json:"usagePercent"`
+}
+
+// ExtendedStats contains both database stats, system stats, and storage usage.
 type ExtendedStats struct {
 	Downloads       int                 `json:"downloads"`
 	Requests        int                 `json:"requests"`
@@ -51,18 +75,19 @@ type ExtendedStats struct {
 	BytesUploaded   int64               `json:"bytesUploaded"`
 	BytesDownloaded int64               `json:"bytesDownloaded"`
 	StartTime       time.Time           `json:"startTime"`
+	Storage         StorageUsage        `json:"storage"`
 	System          *system.SystemStats `json:"system,omitempty"`
 }
 
 // StatsSocketHandler handles WebSocket connections for real-time stats updates
 // It fetches fresh stats from the database and system on each interval and sends them to the client
-func StatsSocketHandler(sharedDir string, allowedOrigins []string, disableSystemStats bool) http.HandlerFunc {
+func StatsSocketHandler(sharedDir string, allowedOrigins []string, disableSystemStats bool, maxStorage int64) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		handleStatsSocket(w, r, sharedDir, allowedOrigins, disableSystemStats)
+		handleStatsSocket(w, r, sharedDir, allowedOrigins, disableSystemStats, maxStorage)
 	}
 }
 
-func handleStatsSocket(w http.ResponseWriter, r *http.Request, sharedDir string, allowedOrigins []string, disableSystemStats bool) {
+func handleStatsSocket(w http.ResponseWriter, r *http.Request, sharedDir string, allowedOrigins []string, disableSystemStats bool, maxStorage int64) {
 	wsUpgrader := newUpgrader(allowedOrigins)
 	conn, err := wsUpgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -87,6 +112,18 @@ func handleStatsSocket(w http.ResponseWriter, r *http.Request, sharedDir string,
 		if err != nil {
 			return ExtendedStats{}, err
 		}
+
+		// Compute Beamdrop-specific storage usage
+		var storageUsage StorageUsage
+		dirUsage, dirErr := storage.GetDirStorageUsage(sharedDir)
+		if dirErr == nil {
+			storageUsage = computeStorageUsage(dirUsage.UsedBytes, dirUsage.TotalBytes, dirUsage.FreeBytes, maxStorage)
+		} else {
+			// Fallback: try to get filesystem stats directly
+			sysStats := system.GetSystemStats(sharedDir)
+			storageUsage = computeStorageUsage(0, sysStats.Disk.Total, sysStats.Disk.Free, maxStorage)
+		}
+
 		ext := ExtendedStats{
 			Downloads:       dbStats.Downloads,
 			Requests:        dbStats.Requests,
@@ -94,6 +131,7 @@ func handleStatsSocket(w http.ResponseWriter, r *http.Request, sharedDir string,
 			BytesUploaded:   dbStats.BytesUploaded,
 			BytesDownloaded: dbStats.BytesDownloaded,
 			StartTime:       dbStats.StartTime,
+			Storage:         storageUsage,
 		}
 		if !disableSystemStats {
 			sysStats := system.GetSystemStats(sharedDir)
@@ -178,4 +216,37 @@ func handleStatsSocket(w http.ResponseWriter, r *http.Request, sharedDir string,
 				"requests", stats.Requests)
 		}
 	}
+}
+
+// computeStorageUsage builds the StorageUsage struct from raw filesystem
+// metrics and the optional maxStorage allocation.
+func computeStorageUsage(usedBytes, totalBytes, freeBytes uint64, maxStorage int64) StorageUsage {
+	s := StorageUsage{
+		UsedBytes:      usedBytes,
+		TotalBytes:     totalBytes,
+		FreeBytes:      freeBytes,
+		AllocatedBytes: maxStorage,
+	}
+
+	if maxStorage > 0 {
+		// A storage cap is configured: available = max(0, cap - used)
+		allocated := uint64(maxStorage)
+		if usedBytes >= allocated {
+			s.AvailableBytes = 0
+			s.UsagePercent = 100.0
+		} else {
+			s.AvailableBytes = allocated - usedBytes
+			if allocated > 0 {
+				s.UsagePercent = float64(usedBytes) / float64(allocated) * 100
+			}
+		}
+	} else {
+		// No cap: available = free space on disk
+		s.AvailableBytes = freeBytes
+		if totalBytes > 0 {
+			s.UsagePercent = float64(usedBytes) / float64(totalBytes) * 100
+		}
+	}
+
+	return s
 }


### PR DESCRIPTION
This PR makes two categories of changes:

1. **New feature** — Beamdrop-specific storage usage metrics in the dashboard (WebSocket + HTTP)
2. **Memory safety fixes** — Three goroutine leaks patched, five excessive-memory-use optimizations applied

---

### Feature: Beamdrop Storage Usage Metrics

**Backend** (`internal/server/websocket.go`, `internal/server/handlers/stats.go`, `internal/server/routes.go`)

- Added `StorageUsage` struct exposing `usedBytes`, `totalBytes`, `freeBytes`, `allocatedBytes`, `availableBytes`, and `usagePercent`
- Both the `/ws/stats` WebSocket and the `/stats` HTTP endpoint now include a `storage` object in their responses
- When `-max-storage` is set, `availableBytes` = `max(0, allocated - used)` and `usagePercent` = `used/allocated × 100`
- When unlimited, `availableBytes` = `freeBytes` and `usagePercent` = `used/total × 100`
- Storage metrics are computed using the already-cached `GetDirStorageUsage()` — no extra filesystem walks

**Frontend** (`static/frontend/src/components/UsageDashboard.tsx`)

- New **"Beamdrop Storage"** section with three cards: a progress bar (capped to allocated limit when set), an available-space stat card (with "Capped"/"Unlimited" badge), and a detail breakdown card
- Header shows a `Max Storage: 10.0 GB` badge when the flag is configured
- Previously the dashboard only showed system-level disk usage (which includes all files on the partition); now it also shows exactly how much space Beamdrop's own files consume