### PR TITLE
feat: add direct download links for shareable links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ cmd/*/*
 .beamdrop/*
 
 beamdrop.db
+docs/.DS_Store
+.DS_Store

--- a/docs/beamdrop-full-docs.md
+++ b/docs/beamdrop-full-docs.md
@@ -1043,6 +1043,7 @@ Content-Type: application/json
 {
   "token": "abc123def456",
   "url": "http://localhost:7777/share/abc123def456",
+  "downloadUrl": "http://localhost:7777/api/shares/download/abc123def456",
   "path": "documents/report.pdf",
   "expiresAt": "2025-01-16T10:30:00Z",
   "createdAt": "2025-01-15T10:30:00Z"
@@ -1155,6 +1156,24 @@ GET /api/shares/access/{token}?mode=download
 ```
 GET /api/shares/access/{token}?mode=inline
 ```
+
+### Download Raw
+
+Returns the raw file bytes directly as a download — no JSON metadata, no preview page. Password-protected links accept the password via the `X-Share-Password` header or `?pwd=` query parameter.
+
+```
+GET /api/shares/download/{token}
+```
+
+**With password:**
+
+```
+GET /api/shares/download/{token}?pwd=my-password
+```
+
+> Directories cannot be downloaded via this endpoint.
+
+**Web UI:** When creating a share link, the dialog shows both a **Preview Link** and a **Download Link**. The Shares Management page (`/shares`) also offers copy buttons for both link types for every active share.
 
 ---
 
@@ -2469,6 +2488,7 @@ When rate limiting is enabled (`-rate-limit N`):
 | `GET`      | `/api/shares/list`                              | Yes     | List shareable links       |
 | `DELETE`   | `/api/shares/delete`                            | Yes     | Delete shareable link      |
 | `GET/POST` | `/api/shares/access/{token}`                    | No      | Access shared content      |
+| `GET`      | `/api/shares/download/{token}`                  | No      | Download raw file bytes    |
 | `GET`      | `/api/v1/keys`                                  | Session | List API keys              |
 | `POST`     | `/api/v1/keys`                                  | Session | Create API key             |
 | `DELETE`   | `/api/v1/keys`                                  | Session | Delete API key             |

--- a/internal/server/handlers/shareable_links.go
+++ b/internal/server/handlers/shareable_links.go
@@ -30,11 +30,12 @@ type CreateShareableLinkRequest struct {
 
 // CreateShareableLinkResponse represents the response after creating a shareable link
 type CreateShareableLinkResponse struct {
-	Token     string     `json:"token"`
-	URL       string     `json:"url"`
-	Path      string     `json:"path"`
-	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
-	CreatedAt time.Time  `json:"createdAt"`
+	Token       string     `json:"token"`
+	URL         string     `json:"url"`
+	DownloadURL string     `json:"downloadUrl"`
+	Path        string     `json:"path"`
+	ExpiresAt   *time.Time `json:"expiresAt,omitempty"`
+	CreatedAt   time.Time  `json:"createdAt"`
 }
 
 // ShareableLinkInfo represents link information without sensitive data
@@ -92,19 +93,21 @@ func (h *ShareableLinkHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Construct the shareable URL
+	// Construct the shareable URL and download URL
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
 	}
 	shareURL := fmt.Sprintf("%s://%s/share/%s", scheme, r.Host, link.Token)
+	downloadURL := fmt.Sprintf("%s://%s/api/shares/download/%s", scheme, r.Host, link.Token)
 
 	response := CreateShareableLinkResponse{
-		Token:     link.Token,
-		URL:       shareURL,
-		Path:      link.Path,
-		ExpiresAt: link.ExpiresAt,
-		CreatedAt: link.CreatedAt,
+		Token:       link.Token,
+		URL:         shareURL,
+		DownloadURL: downloadURL,
+		Path:        link.Path,
+		ExpiresAt:   link.ExpiresAt,
+		CreatedAt:   link.CreatedAt,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -300,6 +303,74 @@ func (h *ShareableLinkHandler) Access(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("Shareable link accessed", "token", token, "path", link.Path)
+}
+
+// DownloadRaw serves the raw file data as a download for a shareable link token
+func (h *ShareableLinkHandler) DownloadRaw(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		sendJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract token from URL path: /api/shares/download/<token>
+	token := strings.TrimPrefix(r.URL.Path, "/api/shares/download/")
+	if token == "" {
+		sendJSONError(w, "Missing token", http.StatusBadRequest)
+		return
+	}
+
+	// Get the shareable link
+	link, err := db.GetShareableLinkByToken(token)
+	if err != nil {
+		slog.Error("Error accessing shareable link", "error", err)
+		sendJSONError(w, "Invalid or expired link", http.StatusNotFound)
+		return
+	}
+	if link == nil {
+		sendJSONError(w, "Link not found", http.StatusNotFound)
+		return
+	}
+
+	// Handle password-protected links
+	if link.PasswordHash != "" {
+		password := r.Header.Get("X-Share-Password")
+		if password == "" {
+			password = r.URL.Query().Get("pwd")
+		}
+		if password == "" {
+			sendJSONError(w, "Password required", http.StatusUnauthorized)
+			return
+		}
+		if !db.ValidateLinkPassword(link, password) {
+			sendJSONError(w, "Invalid password", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	// Resolve the full path
+	fullPath := filepath.Join(h.sharedDir, link.Path)
+
+	fileInfo, err := os.Stat(fullPath)
+	if err != nil {
+		slog.Error("Failed to stat path", "error", err)
+		sendJSONError(w, "File not found", http.StatusNotFound)
+		return
+	}
+	if fileInfo.IsDir() {
+		sendJSONError(w, "Cannot download a directory", http.StatusBadRequest)
+		return
+	}
+
+	// Increment access count
+	if err := db.IncrementAccessCount(token); err != nil {
+		slog.Error("Failed to increment access count", "error", err)
+	}
+
+	// Serve the file as a download
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filepath.Base(link.Path)))
+	http.ServeFile(w, r, fullPath)
+
+	slog.Info("Shareable link downloaded", "token", token, "path", link.Path)
 }
 
 // detectContentType determines the MIME type of a file based on extension

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -80,7 +80,8 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("/api/shares", shareLinkHandler.Create)
 	s.mux.HandleFunc("/api/shares/list", shareLinkHandler.List)
 	s.mux.HandleFunc("/api/shares/delete", shareLinkHandler.Delete)
-	s.mux.HandleFunc("/api/shares/access/", shareLinkHandler.Access) // Public access API endpoint
+	s.mux.HandleFunc("/api/shares/download/", shareLinkHandler.DownloadRaw) // Raw download API endpoint
+	s.mux.HandleFunc("/api/shares/access/", shareLinkHandler.Access)         // Public access API endpoint
 
 	// S3-like API endpoints
 	s.setupS3APIRoutes()

--- a/static/frontend/src/components/ShareLinkDialog.tsx
+++ b/static/frontend/src/components/ShareLinkDialog.tsx
@@ -20,6 +20,7 @@ import {
   Loader2,
   FolderIcon,
   FileIcon,
+  Download,
 } from "lucide-react";
 import {
   Select,
@@ -54,12 +55,14 @@ export function ShareLinkDialog({
   isDir = false,
 }: ShareLinkDialogProps) {
   const [shareLink, setShareLink] = useState<string>("");
+  const [downloadLink, setDownloadLink] = useState<string>("");
   const [expiresAt, setExpiresAt] = useState<string | null>(null);
   const [password, setPassword] = useState<string>("");
   const [expiresIn, setExpiresIn] = useState<string>(""); // in hours
   const [expiryPreset, setExpiryPreset] = useState<string>("none");
   const [isGenerating, setIsGenerating] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copiedDownload, setCopiedDownload] = useState(false);
 
   const getExpiryHours = (): number => {
     if (expiryPreset === "custom") return parseFloat(expiresIn);
@@ -105,6 +108,7 @@ export function ShareLinkDialog({
 
       const data = await response.json();
       setShareLink(data.url);
+      setDownloadLink(data.downloadUrl);
       setExpiresAt(data.expiresAt || null);
 
       toast({
@@ -140,17 +144,37 @@ export function ShareLinkDialog({
     }
   };
 
+  const copyDownloadLink = async () => {
+    try {
+      await navigator.clipboard.writeText(downloadLink);
+      setCopiedDownload(true);
+      setTimeout(() => setCopiedDownload(false), 2000);
+      toast({
+        title: "Copied",
+        description: "Download link copied to clipboard",
+      });
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to copy download link",
+        variant: "destructive",
+      });
+    }
+  };
+
   const openInNewTab = () => {
     window.open(shareLink, "_blank");
   };
 
   const handleClose = () => {
     setShareLink("");
+    setDownloadLink("");
     setPassword("");
     setExpiresIn("");
     setExpiryPreset("none");
     setExpiresAt(null);
     setCopied(false);
+    setCopiedDownload(false);
     onOpenChange(false);
   };
 
@@ -246,7 +270,10 @@ export function ShareLinkDialog({
         ) : (
           <div className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="shareLink">Shareable Link</Label>
+              <Label htmlFor="shareLink" className="flex items-center gap-2">
+                <Link2 className="w-4 h-4" />
+                Preview Link
+              </Label>
               <div className="flex gap-2">
                 <Input
                   id="shareLink"
@@ -277,11 +304,38 @@ export function ShareLinkDialog({
               </div>
             </div>
 
+            <div className="space-y-2">
+              <Label htmlFor="downloadLink" className="flex items-center gap-2">
+                <Download className="w-4 h-4" />
+                Download Link
+              </Label>
+              <div className="flex gap-2">
+                <Input
+                  id="downloadLink"
+                  value={downloadLink}
+                  readOnly
+                  className="font-mono text-sm"
+                />
+                <Button
+                  size="icon"
+                  variant="outline"
+                  onClick={copyDownloadLink}
+                  className="flex-shrink-0"
+                >
+                  {copiedDownload ? (
+                    <Check className="w-4 h-4 text-green-500" />
+                  ) : (
+                    <Copy className="w-4 h-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+
             {password && (
               <div className="p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-md">
                 <p className="text-sm text-yellow-700 dark:text-yellow-400 flex items-center gap-2">
                   <Lock className="w-4 h-4" />
-                  This link is password protected
+                  This link is password protected. Append <code className="text-xs bg-yellow-500/20 px-1 rounded">?pwd=PASSWORD</code> to the download link for direct access.
                 </p>
               </div>
             )}

--- a/static/frontend/src/components/SharesManagementPage.tsx
+++ b/static/frontend/src/components/SharesManagementPage.tsx
@@ -11,6 +11,7 @@ import {
   FileIcon,
   FolderIcon,
   Clock,
+  Download,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -63,6 +64,7 @@ export function SharesManagementPage() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [linkToDelete, setLinkToDelete] = useState<ShareableLink | null>(null);
   const [copiedToken, setCopiedToken] = useState<string | null>(null);
+  const [copiedDownloadToken, setCopiedDownloadToken] = useState<string | null>(null);
 
   const fetchLinks = useCallback(async () => {
     try {
@@ -95,6 +97,25 @@ export function SharesManagementPage() {
       toast({
         title: "Copied",
         description: "Shareable link copied to clipboard",
+      });
+    } catch {
+      toast({
+        title: "Error",
+        description: "Failed to copy to clipboard",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleCopyDownloadLink = async (token: string) => {
+    try {
+      const url = `${window.location.origin}/api/shares/download/${token}`;
+      await navigator.clipboard.writeText(url);
+      setCopiedDownloadToken(token);
+      setTimeout(() => setCopiedDownloadToken(null), 2000);
+      toast({
+        title: "Copied",
+        description: "Download link copied to clipboard",
       });
     } catch {
       toast({
@@ -313,12 +334,24 @@ export function SharesManagementPage() {
                             variant="ghost"
                             size="icon"
                             onClick={() => handleCopyLink(link.token)}
-                            title="Copy link"
+                            title="Copy share link"
                           >
                             {copiedToken === link.token ? (
                               <Check className="w-4 h-4 text-green-500" />
                             ) : (
                               <Copy className="w-4 h-4" />
+                            )}
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleCopyDownloadLink(link.token)}
+                            title="Copy download link"
+                          >
+                            {copiedDownloadToken === link.token ? (
+                              <Check className="w-4 h-4 text-green-500" />
+                            ) : (
+                              <Download className="w-4 h-4" />
                             )}
                           </Button>
                           <Button


### PR DESCRIPTION
## Summary

Adds a new endpoint `GET /api/shares/download/{token}` that serves raw file bytes directly as a download, alongside the existing preview-based share links.

## Changes

### Backend
- **New endpoint** `/api/shares/download/{token}` — serves file with `Content-Disposition: attachment`. Supports password-protected links via `X-Share-Password` header or `?pwd=` query param.
- **Create response** now includes `downloadUrl` field alongside `url`.

### Frontend
- **ShareLinkDialog** — shows both Preview Link and Download Link with independent copy buttons after generation
- **SharesManagementPage** — each share row has a new download link copy button

### Docs/Website
- Updated website shares docs page and full documentation with Download Raw endpoint docs